### PR TITLE
Add instrumentation and test cases for Storage._check_database functions and 

### DIFF
--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 import warnings
@@ -21,6 +22,11 @@ from kinto.core.utils import sqlalchemy as sa
 logger = logging.getLogger(__name__)
 HERE = os.path.dirname(__file__)
 
+# Instrumentation data structure for Storage._check_database_timezone
+coverage_data_check_database_timezone = {
+    "branch 1": 0, "branch 2": 0,
+}
+total_branches_check_database_timezone = len(coverage_data_check_database_timezone)
 
 class Storage(StorageBase, MigratorMixin):
     """Storage backend using PostgreSQL.
@@ -108,7 +114,10 @@ class Storage(StorageBase, MigratorMixin):
         if timezone != "UTC":  # pragma: no cover
             msg = f"Database timezone is not UTC ({timezone})"
             warnings.warn(msg)
+            coverage_data_check_database_timezone["branch 1"] += 1
             logger.warning(msg)
+        else:
+            coverage_data_check_database_timezone["branch 2"] += 1
 
     def _check_database_encoding(self):
         # Make sure database is UTF-8.
@@ -997,6 +1006,18 @@ def load_from_config(config):
     client = create_from_config(config, prefix="storage_")
     return Storage(client=client, max_fetch_size=max_fetch_size, readonly=readonly)
 
+# Function to print coverage data for _check_database_timezone
+def print_coverage_data_check_database_timezone():
+    print("Branch Coverage Report for function Storage._check_database_timezone:")
+    print(f"Number of Branches: {total_branches_check_database_timezone}")
+    total_executed = sum(1 for count in coverage_data_check_database_timezone.values() if count > 0)
+    for branch, count in coverage_data_check_database_timezone.items():
+        print(f"{branch.replace('_', ' ').capitalize()}: executed {count} time(s)")
+    coverage_percentage = (total_executed / total_branches_check_database_timezone) * 100
+    print(f"Total Coverage: {coverage_percentage:.2f}%")
+
+# Add a call to print coverage data at the end of the program
+atexit.register(print_coverage_data_check_database_timezone)
 
 UNKNOWN_SCHEMA_VERSION_MESSAGE = """
 Missing schema history. Perhaps at some point, this Kinto server was

--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -131,7 +131,10 @@ class Storage(StorageBase, MigratorMixin):
             obj = result.fetchone()
         encoding = obj.encoding.lower()
         if encoding != "utf8":  # pragma: no cover
+            coverage_data_check_database_encoding["branch 1"] += 1
             raise AssertionError(f"Unexpected database encoding {encoding}")
+        else:
+            coverage_data_check_database_encoding["branch 2"] += 1
 
     def get_installed_version(self):
         """Return current version of schema or None if not any found."""
@@ -1016,8 +1019,19 @@ def print_coverage_data_check_database_timezone():
     coverage_percentage = (total_executed / total_branches_check_database_timezone) * 100
     print(f"Total Coverage: {coverage_percentage:.2f}%")
 
+# Function to print coverage data for _check_database_encoding
+def print_coverage_data_check_database_encoding():
+    print("Branch Coverage Report for function Storage._check_database_encoding:")
+    print(f"Number of Branches: {total_branches_check_database_encoding}")
+    total_executed = sum(1 for count in coverage_data_check_database_encoding.values() if count > 0)
+    for branch, count in coverage_data_check_database_encoding.items():
+        print(f"{branch.replace('_', ' ').capitalize()}: executed {count} time(s)")
+    coverage_percentage = (total_executed / total_branches_check_database_encoding) * 100
+    print(f"Total Coverage: {coverage_percentage:.2f}%")
+
 # Add a call to print coverage data at the end of the program
 atexit.register(print_coverage_data_check_database_timezone)
+atexit.register(print_coverage_data_check_database_encoding)
 
 UNKNOWN_SCHEMA_VERSION_MESSAGE = """
 Missing schema history. Perhaps at some point, this Kinto server was

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -116,6 +116,26 @@ class StorageTest(unittest.TestCase):
             self.storage._check_database_timezone()
         self.assertEqual(str(cm.exception), 'Unexpected database timezone PST')
 
+    def test_check_database_encoding_utf8(self):
+        # Mock the database response to return UTF-8
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(encoding='utf8')
+        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
+
+        # Call the method and assert that no exception is raised
+        self.storage._check_database_encoding()
+
+    def test_check_database_encoding_non_utf8(self):
+        # Mock the database response to return non-UTF-8
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(encoding='latin1')
+        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
+
+        # Call the method and assert that an AssertionError is raised
+        with self.assertRaises(AssertionError) as cm:
+            self.storage._check_database_encoding()
+        self.assertEqual(str(cm.exception), 'Unexpected database encoding latin1')
+
 
 class MemoryBasedStorageTest(unittest.TestCase):
     def test_backend_raise_not_implemented_error(self):

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,6 +1,7 @@
 from unittest import mock
-
+import unittest
 import pytest
+import logging
 
 from kinto.core import DEFAULT_SETTINGS
 from kinto.core.storage import (
@@ -18,6 +19,7 @@ from kinto.core.storage.utils import paginated
 from kinto.core.testing import skip_if_no_postgresql, unittest
 from kinto.core.utils import COMPARISON
 from kinto.core.utils import sqlalchemy as sa
+from kinto.core.storage.postgresql import Storage
 
 
 class GeneratorTest(unittest.TestCase):
@@ -85,6 +87,34 @@ class StorageBaseTest(unittest.TestCase):
     def test_backenderror_message_default_to_original_exception_message(self):
         error = exceptions.BackendError(ValueError("Pool Error"))
         self.assertEqual(str(error), "ValueError: Pool Error")
+
+# Setting up logger
+logger = logging.getLogger(__name__)
+
+class StorageTest(unittest.TestCase):
+    def setUp(self):
+        self.client_mock = mock.MagicMock()
+        self.storage = Storage(self.client_mock, max_fetch_size=1000)
+
+    def test_check_database_timezone_utc(self):
+        # Mock the database response to return UTC
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(timezone='UTC')
+        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
+
+        # Call the method and assert that no exception is raised
+        self.storage._check_database_timezone()
+
+    def test_check_database_timezone_non_utc(self):
+        # Mock the database response to return non-UTC
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(timezone='PST')
+        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
+
+        # Call the method and assert that an AssertionError is raised
+        with self.assertRaises(AssertionError) as cm:
+            self.storage._check_database_timezone()
+        self.assertEqual(str(cm.exception), 'Unexpected database timezone PST')
 
 
 class MemoryBasedStorageTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it.

Summary of Changes
Added instrumentation to Storage._check_database_timezone(self)
Added instrumentation to Storage._check_database_encoding(self)
Added test cases for Storage._check_database_timezone(self)
Added test cases for Storage._check_database_encoding(self)