### PR TITLE
Add instrumentation and test cases for Statsd.watch_execution_time and Statsd.load_from_config

### DIFF
--- a/kinto/core/statsd.py
+++ b/kinto/core/statsd.py
@@ -6,6 +6,16 @@ from pyramid.exceptions import ConfigurationError
 from kinto.core import utils
 
 
+import atexit
+
+### INSTRUMENTATION BRANCH COVERAGE DATA STRUCTURE ###
+coverage_data_of_watch_execution_time = {
+    "Branch 1": 0,   ## FOR BRANCH OF name in members
+    "Branch 2": 0,   ## IF BRANCH OF not name.startswith("_") and is_method
+    "Branch 3": 0   ## INVISIBLE ELSE BRANCH
+}
+
+
 try:
     import statsd as statsd_module
 except ImportError:  # pragma: no cover
@@ -16,16 +26,24 @@ class Client:
     def __init__(self, host, port, prefix):
         self._client = statsd_module.StatsClient(host, port, prefix=prefix)
 
+    ### SELECTED FUNCTION ###
     def watch_execution_time(self, obj, prefix="", classname=None):
         classname = classname or utils.classname(obj)
         members = dir(obj)
         for name in members:
+            ## BRANCH 1 ##
+            coverage_data_of_watch_execution_time["Branch 1"] += 1
             value = getattr(obj, name)
             is_method = isinstance(value, types.MethodType)
             if not name.startswith("_") and is_method:
+                ## BRANCH 2 ##
+                coverage_data_of_watch_execution_time["Branch 2"] += 1
                 statsd_key = f"{prefix}.{classname}.{name}"
                 decorated_method = self.timer(statsd_key)(value)
                 setattr(obj, name, decorated_method)
+            else:
+                ## BRANCH 3 ##
+                coverage_data_of_watch_execution_time["Branch 3"] += 1
 
     def timer(self, key):
         return self._client.timer(key)
@@ -61,3 +79,20 @@ def load_from_config(config):
         prefix = settings["statsd_prefix"]
 
     return Client(uri.hostname, uri.port, prefix)
+
+
+### FUNCTION TO PRINT COVERAGE DATA INFORMATION ###
+def print_coverage_data():
+    def print_coverage_report(function_name, coverage_data):
+        print(f"Branch Coverage Report for function {function_name}:")
+        print(f"Number of Branches: {len(coverage_data)}")
+        total_executed = sum(1 for count in coverage_data.values() if count > 0)
+        for branch, count in coverage_data.items():
+            print(f"{branch}: executed {count} time(s)")
+        coverage_percentage = (total_executed / len(coverage_data)) * 100
+        print(f"Total Coverage: {coverage_percentage:.2f}% \n")
+
+    print_coverage_report("watch_execution_time", coverage_data_of_watch_execution_time)
+
+### PRINT COVERAGE DATA AT THE END OF THE PROGRAM ###
+atexit.register(print_coverage_data)

--- a/kinto/core/statsd.py
+++ b/kinto/core/statsd.py
@@ -15,6 +15,13 @@ coverage_data_of_watch_execution_time = {
     "Branch 3": 0   ## INVISIBLE ELSE BRANCH
 }
 
+coverage_data_of_load_from_config = {
+    "Branch 1": 0,   ## IF BRANCH OF statsd_module is None
+    "Branch 2": 0,   ## INVISIBLE ELSE BRANCH
+    "Branch 3": 0,   ## IF BRANCH OF settings["project_name"] != ""
+    "Branch 4": 0   ## ELSE BRANCG
+}
+
 
 try:
     import statsd as statsd_module
@@ -60,22 +67,30 @@ def statsd_count(request, count_key):
     if statsd:
         statsd.count(count_key)
 
-
+### SELECTED FUNCTION ###
 def load_from_config(config):
     # If this is called, it means that a ``statsd_url`` was specified in settings.
     # (see ``kinto.core.initialization``)
     # Raise a proper error if the ``statsd`` module is not installed.
     if statsd_module is None:
+        ## BRANCH 1 ##
+        coverage_data_of_load_from_config["Branch 1"] += 1
         error_msg = "Please install Kinto with monitoring dependencies (e.g. statsd package)"
         raise ConfigurationError(error_msg)
+    ## BRANCH 2 ##
+    coverage_data_of_load_from_config["Branch 2"] += 1
 
     settings = config.get_settings()
     uri = settings["statsd_url"]
     uri = urlparse(uri)
 
     if settings["project_name"] != "":
+        ## BRANCH 3 ##
+        coverage_data_of_load_from_config["Branch 3"] += 1
         prefix = settings["project_name"]
     else:
+        ## BRANCH 4 ##
+        coverage_data_of_load_from_config["Branch 4"] += 1
         prefix = settings["statsd_prefix"]
 
     return Client(uri.hostname, uri.port, prefix)
@@ -93,6 +108,7 @@ def print_coverage_data():
         print(f"Total Coverage: {coverage_percentage:.2f}% \n")
 
     print_coverage_report("watch_execution_time", coverage_data_of_watch_execution_time)
+    print_coverage_report("load_from_config", coverage_data_of_load_from_config)
 
 ### PRINT COVERAGE DATA AT THE END OF THE PROGRAM ###
 atexit.register(print_coverage_data)

--- a/tests/core/test_statsd.py
+++ b/tests/core/test_statsd.py
@@ -118,3 +118,33 @@ class TimingTest(BaseWebTest, unittest.TestCase):
             self.app.get("/", headers=self.headers)
             timers = set(c[0][0] for c in mocked.call_args_list)
             self.assertIn("authentication.basicauth.unauthenticated_userid", timers)
+
+
+### ADDITIONAL TEST CASES ###
+
+@mock.patch("kinto.core.statsd.statsd_module")
+class AdditionalStatsdClientTest(unittest.TestCase):
+    def setUp(self):
+        self.settings_with_project_name = {
+            "statsd_url": "udp://foo:1234",
+            "statsd_prefix": "prefix",
+            "project_name": "projectname"
+        }
+        self.settings_without_project_name = {
+            "statsd_url": "udp://foo:1234",
+            "statsd_prefix": "prefix",
+            "project_name": ""
+        }
+
+    ### ADDED TEST CASES FOR watch_execution_time FUNCTION ###
+    def test_watch_execution_time_decorates_public_method(self, module_mock):
+        ## INPUT ##
+        client = statsd.Client("localhost", 1234, "prefix")
+        test_object = TestedClass()
+
+        with mock.patch.object(client, "_client") as mocked_client:
+            client.watch_execution_time(test_object, prefix="test")
+            test_object.test_method()
+            ## ASSERT ##
+            mocked_client.timer.assert_called_with("test.testedclass.test_method")
+    

--- a/tests/core/test_statsd.py
+++ b/tests/core/test_statsd.py
@@ -148,3 +148,19 @@ class AdditionalStatsdClientTest(unittest.TestCase):
             ## ASSERT ##
             mocked_client.timer.assert_called_with("test.testedclass.test_method")
     
+    ### ADDED TEST CASES FOR load_from_config FUNCTION ###
+    def test_load_from_config_with_project_name(self, module_mock):
+        ## INPUT ##
+        config = testing.setUp()
+        config.registry.settings = self.settings_with_project_name
+        statsd.load_from_config(config)
+        ## ASSERT ##
+        module_mock.StatsClient.assert_called_with("foo", 1234, prefix="projectname")
+
+    def test_load_from_config_without_project_name(self, module_mock):
+        ## INPUT ##
+        config = testing.setUp()
+        config.registry.settings = self.settings_without_project_name
+        statsd.load_from_config(config)
+        ## ASSERT ##
+        module_mock.StatsClient.assert_called_with("foo", 1234, prefix="prefix")


### PR DESCRIPTION
Fixes #

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it.

Summary of Changes
Added instrumentation to watch_execution_time function
Added instrumentation to load_from_config function
Added test cases for watch_execution_time function
Added test cases for load_from_config function