### PR TITLE
Fix instrumentation and test cases for Storage._check_database_timezone(self) and _ encoding (self)

### DIFF
--- a/kinto/core/storage/postgresql/__init__.py
+++ b/kinto/core/storage/postgresql/__init__.py
@@ -28,6 +28,12 @@ coverage_data_check_database_timezone = {
 }
 total_branches_check_database_timezone = len(coverage_data_check_database_timezone)
 
+# Instrumentation data structure for Storage._check_database_encoding
+coverage_data_check_database_encoding = {
+    "branch 1": 0, "branch 2": 0,
+}
+total_branches_check_database_encoding = len(coverage_data_check_database_encoding)
+
 class Storage(StorageBase, MigratorMixin):
     """Storage backend using PostgreSQL.
 

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,7 +1,7 @@
-from unittest import mock
 import unittest
+from unittest import mock
+
 import pytest
-import logging
 
 from kinto.core import DEFAULT_SETTINGS
 from kinto.core.storage import (
@@ -88,10 +88,7 @@ class StorageBaseTest(unittest.TestCase):
         error = exceptions.BackendError(ValueError("Pool Error"))
         self.assertEqual(str(error), "ValueError: Pool Error")
 
-# Setting up logger
-logger = logging.getLogger(__name__)
-
-class StorageTest(unittest.TestCase):
+class StorageTimezoneEncodingTest(unittest.TestCase):
     def setUp(self):
         self.client_mock = mock.MagicMock()
         self.storage = Storage(self.client_mock, max_fetch_size=1000)
@@ -111,30 +108,12 @@ class StorageTest(unittest.TestCase):
         mock_conn.execute.return_value.fetchone.return_value = mock.Mock(timezone='PST')
         self.client_mock.connect.return_value.__enter__.return_value = mock_conn
 
-        # Call the method and assert that an AssertionError is raised
-        with self.assertRaises(AssertionError) as cm:
+        # Call the method and assert that a warning is raised
+        with self.assertWarns(Warning):
             self.storage._check_database_timezone()
-        self.assertEqual(str(cm.exception), 'Unexpected database timezone PST')
 
-    def test_check_database_encoding_utf8(self):
-        # Mock the database response to return UTF-8
-        mock_conn = mock.MagicMock()
-        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(encoding='utf8')
-        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
-
-        # Call the method and assert that no exception is raised
-        self.storage._check_database_encoding()
-
-    def test_check_database_encoding_non_utf8(self):
-        # Mock the database response to return non-UTF-8
-        mock_conn = mock.MagicMock()
-        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(encoding='latin1')
-        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
-
-        # Call the method and assert that an AssertionError is raised
-        with self.assertRaises(AssertionError) as cm:
-            self.storage._check_database_encoding()
-        self.assertEqual(str(cm.exception), 'Unexpected database encoding latin1')
+if __name__ == '__main__':
+    unittest.main()
 
 
 class MemoryBasedStorageTest(unittest.TestCase):

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -112,6 +112,25 @@ class StorageTimezoneEncodingTest(unittest.TestCase):
         with self.assertWarns(Warning):
             self.storage._check_database_timezone()
 
+    def test_check_database_encoding_utf8(self):
+        # Mock the database response to return UTF-8
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(encoding='utf8')
+        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
+
+        # Call the method and assert that no exception is raised
+        self.storage._check_database_encoding()
+
+    def test_check_database_encoding_non_utf8(self):
+        # Mock the database response to return non-UTF-8
+        mock_conn = mock.MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = mock.Mock(encoding='latin1')
+        self.client_mock.connect.return_value.__enter__.return_value = mock_conn
+
+        # Call the method and assert that an AssertionError is raised
+        with self.assertRaises(AssertionError):
+            self.storage._check_database_encoding()
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Fixes #

- [ ] Add documentation.
- [x] Add tests.
- [ ] Add a changelog entry.
- [ ] Add your name in the contributors file.
- [ ] If you changed the HTTP API, update the [API_VERSION](https://github.com/Kinto/kinto/blob/main/kinto/__init__.py#L15) constant and add an API changelog entry [in the docs](https://github.com/Kinto/kinto/blob/main/docs/api/index.rst)
- [ ] If you added a new configuration setting, update the [`kinto.tpl`](https://github.com/Kinto/kinto/blob/main/kinto/config/kinto.tpl) file with it.
